### PR TITLE
Declare dependency on gz-math-vendor 1.3.0 (needed for Cone)

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -35,7 +35,8 @@ in a manner suitable for robotic applications
   <test_depend>python3-psutil</test_depend>
   <test_depend>python3-pytest</test_depend>
   <depend>gz_cmake_vendor</depend>
-  <depend>gz_math_vendor</depend>
+  <!-- need gz-math with cone support released at 7.5.0 -->
+  <depend version_gte="1.3.0">gz_math_vendor</depend>
   <depend>gz_utils_vendor</depend>
   <depend>gz_tools_vendor</depend>
 


### PR DESCRIPTION
Cone support was released in gz-math 7.5.0 (vendor 1.3.0) and being used in the released version of sdformat_vendor. The gz-math-vendor package was released in Rolling so new installations have no problems in getting updated versions of gz-math-vendor and sdformat-vendor together but there are use cases where an old system hosting an old version of gz-math-vendor can receive an updated sdformat_vendor without forcing gz-math-vendor to be updated.

See https://github.com/open-rmf/rmf_simulation/actions/runs/10876644502/job/30176851916?pr=131