### PR TITLE
Build Python bindings and support an unversioned shim

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,8 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}-config.cmake
 
 # Configure the Python shim file
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/unversioned_shim.py.in
-               ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}.py
-               @ONLY)
+  ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}.py
+  @ONLY)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}.py
-        DESTINATION "opt/${PROJECT_NAME}/lib/python")
+  DESTINATION "opt/${PROJECT_NAME}/lib/python")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,6 @@ ament_vendor(${LIB_NAME_UNDERSCORE}_vendor
   SATISFIED ${${LIB_NAME_FULL}_FOUND}
   VCS_URL https://github.com/gazebosim/${GITHUB_NAME}.git
   VCS_VERSION ${GITHUB_NAME}${LIB_VER_MAJOR}_${LIB_VER}${LIB_VER_SUFFIX}
-  CMAKE_ARGS
-    -DSKIP_PYBIND11:BOOL=ON
   GLOBAL_HOOK
 )
 
@@ -73,6 +71,8 @@ if(NOT ${${LIB_NAME_FULL}_FOUND})
   # See https://github.com/ament/ament_package/issues/145
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.sh "# Dummy .sh file needed for .dsv file to be sourced.")
   ament_environment_hooks("${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.sh")
+  # environment hook for setting PYTHONPATH
+  ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}_pythonpath.dsv.in")
 endif()
 
 # The goal is to support versionless package names once the user has found the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,3 +111,11 @@ write_basic_package_version_file(
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}-config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}-config-version.cmake
         DESTINATION "opt/${PROJECT_NAME}/extra_cmake/lib/cmake/${LIB_NAME}")
+
+# Configure the Python shim file
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/unversioned_shim.py.in
+               ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}.py
+               @ONLY)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}.py
+        DESTINATION "opt/${PROJECT_NAME}/lib/python")

--- a/sdformat_vendor_pythonpath.dsv.in
+++ b/sdformat_vendor_pythonpath.dsv.in
@@ -1,0 +1,1 @@
+prepend-non-duplicate-if-exists;PYTHONPATH;opt/@PROJECT_NAME@/lib/python

--- a/unversioned_shim.py.in
+++ b/unversioned_shim.py.in
@@ -1,0 +1,14 @@
+"""
+Shim layer for @LIB_NAME_FULL@ module.
+Allows users to 'import @LIB_NAME@' instead of 'import @LIB_NAME_FULL@'.
+"""
+
+# Re-export everything from @LIB_NAME_FULL@
+from @LIB_NAME_FULL@ import *
+
+# Preserve the original module reference
+import @LIB_NAME_FULL@ as _@LIB_NAME_UNDERSCORE@@LIB_VER_MAJOR@
+import sys
+
+# Make this module behave exactly like @LIB_NAME_FULL@
+sys.modules[__name__].__dict__.update(_@LIB_NAME_UNDERSCORE@@LIB_VER_MAJOR@.__dict__)


### PR DESCRIPTION
The PR includes two commits:

efb124c17c07e1ca72860fc2b6f6fe7db07ed825 is a copy of what we have done in Rolling to add the needed PYTHONPATH and start building Python modules.

The second commits is part of https://github.com/gazebo-tooling/gz_vendor/issues/2 that allows the releases previous to Kilted (Gazebo Jetty) to use unversioned Python modules. This adds a python file to act as a shim layer importing everything from the versioned module so `import sdformat as sdf` can be done.